### PR TITLE
Don't explicitly depend on i18n version

### DIFF
--- a/rspec-subject-extensions.gemspec
+++ b/rspec-subject-extensions.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_runtime_dependency "activesupport", ">= 3.2"
-  s.add_runtime_dependency "i18n", "~> 0.6.0"
   s.add_runtime_dependency "rspec", "~> 3.0"
 
   s.add_development_dependency "appraisal", "~> 1.0"


### PR DESCRIPTION
Instead, whatever is provided by ActiveSupport should be enough.
